### PR TITLE
Fix year formatting and keep ROI formulas

### DIFF
--- a/formatting.py
+++ b/formatting.py
@@ -95,7 +95,7 @@ def sayfa_bicimlendir_xlsxwriter(sheet, workbook):
         sheet.set_row(30, None, percent_format)  # Yıllık İşçilik Maaş Artışı
         
         # Yardımcı sütunlar için biçimlendirme
-        year_col_format = workbook.add_format({'num_format': '0'})
+        year_col_format = workbook.add_format({'num_format': '0 "yıl"'})
         sheet.set_column('D:D', 10, year_col_format)  # Yıl sütunu
         sheet.set_column('E:E', 20, cell_format)  # Yıllık Getiri sütunu
         sheet.set_column('F:F', 20, cell_format)  # Bugünkü Değer sütunu
@@ -129,7 +129,7 @@ def sutun_genislikleri_ayarla_xlsxwriter(sheet, workbook=None):
     sheet.set_column('B:B', 20)  # B sütunu genişliği
     if sheet.name == "4-Özet ve ROI" and workbook:
         sheet.set_column('C:C', 10)  # Grafikler için boşluk
-        year_col_format = workbook.add_format({'num_format': '0'})
+        year_col_format = workbook.add_format({'num_format': '0 "yıl"'})
         sheet.set_column('D:D', 10, year_col_format)  # Yıl sütunu
         sheet.set_column('E:E', 20)  # Yıllık Getiri sütunu
         sheet.set_column('F:F', 20)  # Bugünkü Değer sütunu

--- a/gui.py
+++ b/gui.py
@@ -431,7 +431,9 @@ class ROIHesaplamaArayuzu(QMainWindow):
             ozet_sayfasi['E1'].value = "Yıllık Getiri (TL)"
             ozet_sayfasi['F1'].value = "Bugünkü Değer (TL)"
             for i in range(1, 6):
-                ozet_sayfasi[f'D{i+3}'].value = i  # D4:D8: 1’den 5’e kadar yıllar
+                cell = ozet_sayfasi[f'D{i+3}']
+                cell.value = i  # D4:D8: 1’den 5’e kadar yıllar
+                cell.number_format = '0 "Yıl"'
 
             # E ve F sütunlarındaki formülleri ekle
             ozet_sayfasi['E4'].value = '=B18'  # 1. yıl getirisi

--- a/xlsx_report.py
+++ b/xlsx_report.py
@@ -14,7 +14,6 @@ from formatting import (
     sayfa_bicimlendir_xlsxwriter,
     sutun_genislikleri_ayarla_xlsxwriter,
     grafik_ekle_xlsxwriter,
-    roi_detay_hesapla,
 )
 
 
@@ -159,8 +158,9 @@ def create_xlsxwriter_report(data, filename="roi_report_xlsxwriter.xlsx"):
         summary.write_formula("B22", "=IF(B11>0,B18/B11,0)")
         summary.write_formula("B23", "=IF(B18>0,B11/B18,0)")
 
+        year_format = workbook.add_format({"num_format": '0 "yıl"'})
         for i in range(5):
-            summary.write(i + 3, 3, i + 1)
+            summary.write_number(i + 3, 3, i + 1, year_format)
 
         summary.write_formula("E4", "=B18")
         summary.write_formula("E5", "=E4*(1+B34)")
@@ -183,10 +183,6 @@ def create_xlsxwriter_report(data, filename="roi_report_xlsxwriter.xlsx"):
             "B28",
             "=IF(B11>0,B27/(1+B32)^B33-B11,0)",
         )
-
-        toplam_yatirim = 12000000 + 450000 + 35000 + 5000 + 45000
-        toplam_getiri = maliyet_tasarrufu + verim_artisi + kalite_gelir
-        roi_detay_hesapla(summary, toplam_yatirim, toplam_getiri)
 
         # Helper cells for NPV comparison chart now stored on "Grafikler" sheet
         charts = workbook.get_worksheet_by_name("Grafikler")


### PR DESCRIPTION
## Summary
- show years for D4:D8 instead of TL
- keep formulas in E4:H8 when using xlsxwriter

## Testing
- `python -m py_compile $(git ls-files '*.py')`