### PR TITLE
Auto-run ROI analysis on GUI startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Aracın çalışabilmesi için `openpyxl` paketinin kurulu olması gerekir.
 
 `roi_analyses.py` dosyası, klasördeki `.xlsx` raporlarını listeleyen
 basit bir PyQt5 arayüzü sunar. Varsayılan olarak en yeni dosya seçilir ve
-"Yorumla" butonuna basıldığında rapordaki metrikler analiz edilerek ekranda
-gösterilir.
+araç açıldığında bu raporun değerlendirmesi otomatik olarak gösterilir.
+İstenirse "Yorumla" butonuyla farklı bir dosyanın analizi de yapılabilir.
 
 ```bash
 python roi_analyses.py

--- a/roi_analyses.py
+++ b/roi_analyses.py
@@ -46,6 +46,9 @@ class ROIAnalysesWindow(QWidget):
         layout.addWidget(self.text)
 
         self.refresh_files()
+        # Automatically analyze the most recent report after the combo box
+        # has been populated with available files and the newest one selected.
+        self.run_analysis()
 
     def refresh_files(self) -> None:
         files = [f for f in glob(os.path.join(self.folder, "*.xlsx")) if os.path.isfile(f)]


### PR DESCRIPTION
## Summary
- launch ROI analysis right after populating the combo box
- describe automatic evaluation in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python roi_analyses.py` *(fails: ModuleNotFoundError: No module named 'PyQt5')*